### PR TITLE
Support k3s provider prefix

### DIFF
--- a/.github/workflows/build-cloud-controller-manager.yaml
+++ b/.github/workflows/build-cloud-controller-manager.yaml
@@ -3,32 +3,32 @@ on:
   push:
     tags:
       - '*'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - 
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - 
-        name: Set up Docker Metadata
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             cr.brightbox.com/${{ vars.CR_ACCOUNT }}/${{ vars.CR_REPO }}/brightbox-cloud-controller-manager
           tags: |
             type=semver,pattern={{version}}
-      - 
-        name: Login to Brightbox Container Registry
-        uses: docker/login-action@v2
+            type=ref,event=pr
+      - name: Login to Brightbox Container Registry
+        uses: docker/login-action@v3
         with:
           registry: cr.brightbox.com
           username: ${{ vars.CR_USERNAME }}
           password: ${{ secrets.CR_SECRET }}
-      - 
-        name: Docker build and push
-        uses: docker/build-push-action@v4
+      - name: Docker build and push
+        uses: docker/build-push-action@v6
         with:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test-prs.yaml
+++ b/.github/workflows/test-prs.yaml
@@ -1,15 +1,45 @@
-name: "Test Pull Requests"
+name: "Test And Build Pull Requests"
 
-on: 
+on:
   pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
       - name: Test
-        uses: robherley/go-test-action@v0.1.0
+        uses: robherley/go-test-action@v0.7.1
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            cr.brightbox.com/${{ vars.CR_ACCOUNT }}/${{ vars.CR_REPO }}/brightbox-cloud-controller-manager
+          tags: |
+            type=ref,event=pr
+      - name: Login to Brightbox Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: cr.brightbox.com
+          username: ${{ vars.CR_USERNAME }}
+          password: ${{ secrets.CR_SECRET }}
+      - name: Docker build and push
+        uses: docker/build-push-action@v6
+        with:
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/brightbox/load_balancer.go
+++ b/brightbox/load_balancer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/brightbox/k8ssdk/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"strings"
 )
 
 var (
@@ -79,8 +80,8 @@ func buildLoadBalancerNodes(nodes []*v1.Node) []brightbox.LoadBalancerNode {
 	}
 	result := make([]brightbox.LoadBalancerNode, 0, len(nodes))
 	for i := range nodes {
-		if nodes[i].Spec.ProviderID == "" {
-			klog.Warningf("node %q did not have providerID set", nodes[i].Name)
+		if !strings.HasPrefix(nodes[i].Spec.ProviderID, "brightbox") {
+			klog.Warningf("ignoring node %q with providerID %q", nodes[i].Name, nodes[i].Spec.ProviderID)
 			continue
 		}
 		result = append(result, brightbox.LoadBalancerNode{Node: k8ssdk.MapProviderIDToServerID(nodes[i].Spec.ProviderID)})

--- a/brightbox/load_balancer_firewall.go
+++ b/brightbox/load_balancer_firewall.go
@@ -24,6 +24,7 @@ import (
 	"github.com/brightbox/k8ssdk/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"strings"
 )
 
 var defaultRegionCidr = "10.0.0.0/8"
@@ -130,8 +131,8 @@ func createPortListString(apiservice *v1.Service) string {
 func mapNodesToServerIDs(nodes []*v1.Node) []string {
 	result := make([]string, 0, len(nodes))
 	for i := range nodes {
-		if nodes[i].Spec.ProviderID == "" {
-			klog.Warningf("node %q did not have providerID set", nodes[i].Name)
+		if !strings.HasPrefix(nodes[i].Spec.ProviderID, "brightbox") {
+			klog.Warningf("ignoring node %q with providerID %q", nodes[i].Name, nodes[i].Spec.ProviderID)
 			continue
 		}
 		result = append(result, k8ssdk.MapProviderIDToServerID(nodes[i].Spec.ProviderID))

--- a/brightbox/util.go
+++ b/brightbox/util.go
@@ -87,7 +87,15 @@ func mapNodeToServerID(node *v1.Node) string {
 	if node.Spec.ProviderID == "" {
 		return node.Name
 	}
-	return k8ssdk.MapProviderIDToServerID(node.Spec.ProviderID)
+
+	parts := strings.SplitN(node.Spec.ProviderID, "://", 2)
+
+	if len(parts) == 2 {
+		// some providers have 3 forward slashes so handle that
+		return strings.TrimPrefix(parts[1], "/")
+	}
+
+	return parts[0]
 }
 
 func mapServerIDToNode(name string) *v1.Node {

--- a/brightbox/util_test.go
+++ b/brightbox/util_test.go
@@ -91,6 +91,19 @@ func TestMapNodeToServerID(t *testing.T) {
 	if serverID != expected {
 		t.Errorf("Expected ServerID to be '%s', got '%s'", expected, serverID)
 	}
+	node = &v1.Node{Spec: v1.NodeSpec{ProviderID: "k3s://server789"}}
+	serverID = mapNodeToServerID(node)
+	expected = "server789"
+	if serverID != expected {
+		t.Errorf("Expected ServerID to be '%s', got '%s'", expected, serverID)
+	}
+	node = &v1.Node{Spec: v1.NodeSpec{ProviderID: ""}}
+	node.Name = "server789"
+	serverID = mapNodeToServerID(node)
+	expected = "server789"
+	if serverID != expected {
+		t.Errorf("Expected ServerID to be '%s', got '%s'", expected, serverID)
+	}
 }
 
 // TestMapServerIDToNode verifies that a ServerID is correctly mapped to a Node with that ID as name


### PR DESCRIPTION
previously we only stripped the brightbox:// prefix but would then go on to try
use any other providerIDs with the api. So instead, strip all provider prefixes
and trust the Brightbox API to be the authority on what is a brightbox server
and what is not.

This fixes using the provider with k3s, which uses a k3s:// provider prefix, but
should also work for future prefixes.